### PR TITLE
Support for RPM based Linux systems and alternate MagicMirror install location

### DIFF
--- a/installer/preinstall.sh
+++ b/installer/preinstall.sh
@@ -53,11 +53,33 @@ fi
 
 echo
 
-# check dependencies
-dependencies=(libmagic-dev libatlas-base-dev sox libsox-fmt-all build-essential)
-Installer_info "Checking all dependencies..."
-Installer_check_dependencies
-Installer_success "All Dependencies needed are installed !"
+# Required packages on Debian based systems
+deb_dependencies=(libmagic-dev libatlas-base-dev sox libsox-fmt-all build-essential)
+# Required packages on RPM based systems
+rpm_dependencies=(blas-devel file-libs sox sox-devel wget autoconf automake binutils bison flex gcc gcc-c++ glibc-devel libtool make pkgconf strace byacc ccache cscope ctags elfutils indent ltrace perf valgrind)
+# Check dependencies
+if [ "${debian}" ]
+then
+  dependencies=( "${deb_dependencies[@]}" )
+else
+  if [ "${have_dnf}" ]
+  then
+    dependencies=( "${rpm_dependencies[@]}" )
+  else
+    if [ "${have_yum}" ]
+    then
+      dependencies=( "${rpm_dependencies[@]}" )
+    else
+      dependencies=( "${deb_dependencies[@]}" )
+    fi
+  fi
+fi
+
+[ "${__NO_DEP_CHECK__}" ] || {
+  Installer_info "Checking all dependencies..."
+  Installer_check_dependencies
+  Installer_success "All Dependencies needed are installed !"
+}
 
 cd ..
 

--- a/installer/rebuild.sh
+++ b/installer/rebuild.sh
@@ -26,7 +26,26 @@ Installer_warning "This script will erase current build and reinstall it"
 Installer_error "Use this script only for the new version of Magic Mirror or developer request"
 Installer_yesno "Do you want to continue ?" || exit 0
 
-cd ~/MagicMirror/modules/MMM-Detector
+MMHOME="${HOME}/MagicMirror"
+[ -d ${MMHOME}/modules/MMM-Detector ] || {
+  MMHOME=
+  for homedir in /usr/local /home/*
+  do
+    [ "${homedir}" == "/home/*" ] && continue
+    [ -d ${homedir}/MagicMirror/modules/MMM-Detector ] && {
+      MMHOME="${homedir}/MagicMirror"
+      break
+    }
+  done
+}
+
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-Detector
+else
+  cd ~/MagicMirror/modules/MMM-Detector
+fi
+
 echo
 Installer_info "Deleting: package-lock.json node_modules" 
 rm -rf package.json package-lock.json node_modules

--- a/installer/update.sh
+++ b/installer/update.sh
@@ -23,7 +23,26 @@ source utils.sh
 Installer_info "Welcome to MMM-Detector updater !"
 echo
 
-cd ~/MagicMirror/modules/MMM-Detector
+MMHOME="${HOME}/MagicMirror"
+[ -d ${MMHOME}/modules/MMM-Detector ] || {
+  MMHOME=
+  for homedir in /usr/local /home/*
+  do
+    [ "${homedir}" == "/home/*" ] && continue
+    [ -d ${homedir}/MagicMirror/modules/MMM-Detector ] && {
+      MMHOME="${homedir}/MagicMirror"
+      break
+    }
+  done
+}
+
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-Detector
+else
+  cd ~/MagicMirror/modules/MMM-Detector
+fi
+
 # deleting package.json because npm install add/update package
 rm -f package.json package-lock.json
 
@@ -33,12 +52,22 @@ git reset --hard HEAD
 git pull
 #fresh package.json
 git checkout package.json
-cd ~/MagicMirror/modules/MMM-Detector/node_modules
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-Detector/node_modules
+else
+  cd ~/MagicMirror/modules/MMM-Detector/node_modules
+fi
 
 Installer_info "Deleting ALL @bugsounet libraries..."
 
 rm -rf @bugsounet
-cd ~/MagicMirror/modules/MMM-Detector
+if [ "${MMHOME}" ]
+then
+  cd ${MMHOME}/modules/MMM-Detector
+else
+  cd ~/MagicMirror/modules/MMM-Detector
+fi
 
 Installer_info "Ready for Installing..."
 

--- a/installer/utils.sh
+++ b/installer/utils.sh
@@ -39,6 +39,18 @@ Installer_checkOS () {
     *)        Installer_error "$OSTYPE is not a supported platform"
               exit 0;;
   esac
+
+  # Check if this is a Debian or RPM based system
+  debian=
+  have_apt=`type -p apt-get`
+  have_dpkg=`type -p dpkg`
+  have_dnf=`type -p dnf`
+  have_yum=`type -p yum`
+  [ -f /etc/os-release ] && {
+    id_like="$(cat /etc/os-release | grep ^ID_LIKE= | cut -f2 -d=)"
+  }
+  [ "${id_like}" == "debian" ] && debian=1
+  [ "${debian}" ] || [ -f /etc/debian_version ] && debian=1
 }
 
 # check if all dependencies are installed
@@ -66,25 +78,6 @@ Installer_check_dependencies () {
     Installer_warning "Please logout and login for new group permissions to take effect, then restart npm install"
     exit
   fi
-}
-
-# check the version of GCC and downgrade it if it's not 7
-Installer_check_gcc7 () {
-	Installer_debug "gcc: $Installer_gcc"
-	Installer_debug "gcc revision: $Installer_gcc_rev"
-	Installer_debug "gcc version: $Installer_gcc_version"
-	if [[ "$Installer_gcc_version" != "7" ]]; then
-		Installer_debug "Forced script to reconize as GCC 8"
-		Installer_warning "You are using GCC $Installer_gcc_version, this is not compatible with this program."
-		Installer_warning "You have to downgrade to GCC 7."
-		Installer_yesno "Do you want to make changes ?" || exit 1
-		Installer_info "Installing GCC 7..."
-		sudo apt-get install gcc-7 || exit 1
-		Installer_success "GCC 7 installed"
-		Installer_info "Making GCC 7 by default..."
-		sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 10 || exit 1
-		sudo update-alternatives --config gcc || exit 1
-	fi
 }
 
 # Do electron rebuild
@@ -198,22 +191,89 @@ Installer_gcc_version="$(echo $Installer_gcc_rev | cut -c1)"
 
 #  Installer_update
 Installer_update () {
-  sudo apt-get update -y
+  if [ "${debian}" ]
+  then
+    sudo apt-get update -y
+  else
+    if [ "${have_dnf}" ]
+    then
+      sudo dnf makecache --refresh
+    else
+      if [ "${have_yum}" ]
+      then
+        sudo yum makecache --refresh
+      else
+        sudo apt-get update -y
+      fi
+    fi
+  fi
 }
 
 # indicates if a package is installed
 #
 # $1 - package to verify
 Installer_is_installed () {
-  hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+  if [ "${debian}" ]
+  then
+    if [ "${have_dpkg}" ]
+    then
+      hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+    else
+      if [ "${have_apt}" ]
+      then
+        hash "$1" 2>/dev/null || (apt-cache policy "$1" 2>/dev/null | grep -q "Installed")
+      else
+        hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+      fi
+    fi
+  else
+    if [ "${have_dnf}" ]
+    then
+      hash "$1" 2>/dev/null || (dnf list installed "$1" > /dev/null 2>&1)
+    else
+      if [ "${have_yum}" ]
+      then
+        hash "$1" 2>/dev/null || (yum list installed "$1" > /dev/null 2>&1)
+      else
+        hash "$1" 2>/dev/null || (dpkg -s "$1" 2>/dev/null | grep -q "installed")
+      fi
+    fi
+  fi
 }
 
 # install packages, used for dependencies
 #
 # $@ - list of packages to install
 Installer_install () {
-  sudo apt-get install -y $@
-  sudo apt-get clean
+  if [ "${debian}" ]
+  then
+    if [ "${have_apt}" ]
+    then
+        sudo apt-get install -y $@
+        sudo apt-get clean
+    else
+      if [ "${have_dpkg}" ]
+      then
+        sudo dpkg -i $@
+      else
+        sudo apt install $@
+        sudo apt clean
+      fi
+    fi
+  else
+    if [ "${have_dnf}" ]
+    then
+      sudo dnf -y install $@
+    else
+      if [ "${have_yum}" ]
+      then
+        sudo yum -y install $@
+      else
+        sudo apt install $@
+        sudo apt clean
+      fi
+    fi
+  fi
 }
 
 # remove packages, used for uninstalls
@@ -222,7 +282,32 @@ Installer_install () {
 Installer_remove () {
   echo
   Installer_info "Removing $@"
-  sudo apt-get autoremove --purge $@
+  if [ "${debian}" ]
+  then
+    if [ "${have_apt}" ]
+    then
+      sudo apt-get autoremove --purge $@
+    else
+      if [ "${have_dpkg}" ]
+      then
+        sudo dpkg -P $@
+      else
+        sudo apt-get autoremove --purge $@
+      fi
+    fi
+  else
+    if [ "${have_dnf}" ]
+    then
+      sudo dnf autoremove $@
+    else
+      if [ "${have_yum}" ]
+      then
+        sudo yum autoremove $@
+      else
+        sudo apt-get autoremove --purge $@
+      fi
+    fi
+  fi
   echo
 }
 


### PR DESCRIPTION
This pull request includes changes to support installation on RPM based Linux systems and MagicMirror installations in locations other than ~/MagicMirror.

Extending support for RPM based Linux systems may not seem desirable and it does require some work but I've been able to deploy MagicMirror and all the modules I use on Fedora Linux successfully after making these types of changes. The risk is, I believe, fairly low since the changes are not complicated. Still, it's your call as to whether you wish to extend support beyond `apt-get` Debian installs.

The one area of this pull request that may need tweaking is the list of RPM dependencies. My guess is that some of the packages listed in the RPM dependencies may not be required or that there may be some simpler way to express these dependencies. But, my tests were successful with these.